### PR TITLE
Поддержка стилей для size="large" | "medium"

### DIFF
--- a/src/Markdown/Markdown.styled.ts
+++ b/src/Markdown/Markdown.styled.ts
@@ -164,11 +164,11 @@ const extendThemeConfigWithSized = (config: MutableTheme): ReactUIThemeType => {
   const finalConfig: MutableTheme = {};
   const configKeys = Object.keys(config) as KeyOfReactUITheme[];
 
-  configKeys.forEach(e => {
-    if (e !== 'prototype') {
-      finalConfig[`${e}Small` as KeyOfReactUITheme] = config[e];
-      finalConfig[`${e}Medium` as KeyOfReactUITheme] = config[e];
-      finalConfig[`${e}Large` as KeyOfReactUITheme] = config[e];
+  configKeys.forEach(key => {
+    if (key !== 'prototype') {
+      finalConfig[`${key}Small` as KeyOfReactUITheme] = config[key];
+      finalConfig[`${key}Medium` as KeyOfReactUITheme] = config[key];
+      finalConfig[`${key}Large` as KeyOfReactUITheme] = config[key];
     }
   });
 

--- a/src/Markdown/Markdown.styled.ts
+++ b/src/Markdown/Markdown.styled.ts
@@ -1,4 +1,5 @@
 import { Button, MenuItem, ThemeFactory, THEME_2022 } from '@skbkontur/react-ui';
+import { ThemeIn } from '@skbkontur/react-ui/cjs/lib/theming/Theme';
 import { CSSProperties } from 'react';
 
 import { HorizontalPaddings, Nullable, ReactUIThemeType } from './types';
@@ -156,6 +157,21 @@ export const VisuallyHidden = styled.span`
   border: 0;
 `;
 
+const extendThemeConfigWithSized = (config: ThemeIn): ThemeIn => {
+  let newConfig: Partial<ThemeIn> = { ...config };
+
+  (Object.keys(config) as (keyof ThemeIn)[]).forEach(field => {
+    newConfig = {
+      ...newConfig,
+      [`${field}Large`]: config[field],
+      [`${field}Medium`]: config[field],
+      [`${field}Small`]: config[field],
+    };
+  });
+
+  return newConfig;
+};
+
 export const getMarkdownReactUiTheme = (
   theme: MarkdownTheme,
   reactUiTheme?: typeof THEME_2022,
@@ -167,12 +183,19 @@ export const getMarkdownReactUiTheme = (
 
   return ThemeFactory.create(
     {
-      tabFontSize: elementsFontSize,
-      tabPaddingY: '0',
-      tabPaddingX: '6px',
+      ...extendThemeConfigWithSized({
+        tabFontSize: elementsFontSize,
+        tabPaddingY: '0',
+        tabPaddingX: '6px',
+        tabLineHeight: elementsLineHeight,
+        checkboxPaddingY: '0',
+        checkboxBoxSize: elementsFontSize,
+        menuItemFontSize: elementsFontSize,
+        menuItemPaddingY: '4px',
+        menuItemPaddingX: '28px',
+      }),
       tabColorHover: 'transparent',
       tabColorFocus: 'transparent',
-      tabLineHeight: elementsLineHeight,
       tabBorderWidth: '0',
       selectBorderWidth: '0',
       btnDefaultBg: 'transparent',
@@ -182,7 +205,6 @@ export const getMarkdownReactUiTheme = (
       btnDisabledTextColor: colors.disabledButton,
       btnDefaultHoverBg: themeMode === 'light' ? reactUiTheme?.btnDefaultHoverBg : reactUiTheme?.btnDisabledBg,
       btnFontSizeSmall: elementsFontSize,
-      checkboxPaddingY: '0',
       checkboxBg: 'transparent',
       checkboxHoverBg: 'transparent',
       checkboxCheckedBg: 'transparent',
@@ -193,19 +215,15 @@ export const getMarkdownReactUiTheme = (
       checkboxCheckedActiveShadow: `0 0 0 1px ${colors.grayDefault}`,
       checkboxShadowActive: `0 0 0 1px ${colors.grayDefault}`,
       checkboxCheckedColor: colors.grayDefault,
-      checkboxBoxSize: elementsFontSize,
-      menuItemFontSize: elementsFontSize,
-      menuItemPaddingY: '4px',
-      menuItemPaddingX: '28px',
       hintFontSize: elementsFontSize,
       hintColor: themeMode === 'light' ? colors.white : colors.grayDefault,
       selectPaddingXSmall: '8px',
       selectLineHeightSmall: '24px',
       dropdownBorderWidth: '0',
       ...(panelHorizontalPadding &&
-        ({
+        (extendThemeConfigWithSized({
           textareaPaddingX: `${panelHorizontalPadding}px`,
-        } as ReactUIThemeType)),
+        }) as ReactUIThemeType)),
       ...(borderless &&
         ({
           textareaBorderColor: 'transparent',
@@ -215,13 +233,15 @@ export const getMarkdownReactUiTheme = (
         } as ReactUIThemeType)),
       ...(fullScreenTextareaPadding &&
         ({
-          textareaMinHeight: '85vh',
           textareaBorderColor: 'transparent',
           textareaBorderColorFocus: 'transparent',
           textareaBorderTopColor: 'transparent',
           textareaShadow: 'none',
-          textareaPaddingX: `${fullScreenTextareaPadding}px`,
-          textareaPaddingY: `0`,
+          ...extendThemeConfigWithSized({
+            textareaMinHeight: '85vh',
+            textareaPaddingX: `${fullScreenTextareaPadding}px`,
+            textareaPaddingY: '0',
+          }),
         } as ReactUIThemeType)),
     },
     reactUiTheme,

--- a/src/Markdown/Markdown.styled.ts
+++ b/src/Markdown/Markdown.styled.ts
@@ -158,18 +158,14 @@ export const VisuallyHidden = styled.span`
 `;
 
 const extendThemeConfigWithSized = (config: ThemeIn): ThemeIn => {
-  let newConfig: Partial<ThemeIn> = { ...config };
-
-  (Object.keys(config) as (keyof ThemeIn)[]).forEach(field => {
-    newConfig = {
-      ...newConfig,
+  return (Object.keys(config) as (keyof ThemeIn)[]).reduce((prevConfig, field) => {
+    return {
+      ...prevConfig,
       [`${field}Large`]: config[field],
       [`${field}Medium`]: config[field],
       [`${field}Small`]: config[field],
     };
-  });
-
-  return newConfig;
+  }, config);
 };
 
 export const getMarkdownReactUiTheme = (

--- a/src/Markdown/Markdown.styled.ts
+++ b/src/Markdown/Markdown.styled.ts
@@ -166,13 +166,9 @@ const extendThemeConfigWithSized = (config: MutableTheme): ReactUIThemeType => {
 
   configKeys.forEach(e => {
     if (e !== 'prototype') {
-      const smallKey = `${e}Small` as KeyOfReactUITheme;
-      const mediumKey = `${e}Medium` as KeyOfReactUITheme;
-      const largeKey = `${e}Large` as KeyOfReactUITheme;
-
-      if (smallKey in finalConfig) finalConfig[smallKey] = config[e];
-      if (mediumKey in finalConfig) finalConfig[mediumKey] = config[e];
-      if (largeKey in finalConfig) finalConfig[largeKey] = config[e];
+      finalConfig[`${e}Small` as KeyOfReactUITheme] = config[e];
+      finalConfig[`${e}Medium` as KeyOfReactUITheme] = config[e];
+      finalConfig[`${e}Large` as KeyOfReactUITheme] = config[e];
     }
   });
 

--- a/src/Markdown/Markdown.styled.ts
+++ b/src/Markdown/Markdown.styled.ts
@@ -1,5 +1,4 @@
 import { Button, MenuItem, ThemeFactory, THEME_2022 } from '@skbkontur/react-ui';
-import { ThemeIn } from '@skbkontur/react-ui/cjs/lib/theming/Theme';
 import { CSSProperties } from 'react';
 
 import { HorizontalPaddings, Nullable, ReactUIThemeType } from './types';
@@ -9,6 +8,10 @@ import { MarkdownTheme } from '../styles/theme';
 interface PanelProps extends HorizontalPaddings {
   theme: MarkdownTheme;
 }
+
+type MutableTheme = { -readonly [K in keyof ReactUIThemeType]?: ReactUIThemeType[K] };
+
+type KeyOfReactUITheme = keyof ReactUIThemeType;
 
 const panelStyle = ({ panelPadding, theme }: PanelProps) => css`
   padding: 6px ${panelPadding ?? 0}px;
@@ -157,15 +160,23 @@ export const VisuallyHidden = styled.span`
   border: 0;
 `;
 
-const extendThemeConfigWithSized = (config: ThemeIn): ThemeIn => {
-  return (Object.keys(config) as (keyof ThemeIn)[]).reduce((prevConfig, field) => {
-    return {
-      ...prevConfig,
-      [`${field}Large`]: config[field],
-      [`${field}Medium`]: config[field],
-      [`${field}Small`]: config[field],
-    };
-  }, config);
+const extendThemeConfigWithSized = (config: MutableTheme): ReactUIThemeType => {
+  const finalConfig: MutableTheme = {};
+  const configKeys = Object.keys(config) as KeyOfReactUITheme[];
+
+  configKeys.forEach(e => {
+    if (e !== 'prototype') {
+      const smallKey = `${e}Small` as KeyOfReactUITheme;
+      const mediumKey = `${e}Medium` as KeyOfReactUITheme;
+      const largeKey = `${e}Large` as KeyOfReactUITheme;
+
+      if (smallKey in finalConfig) finalConfig[smallKey] = config[e];
+      if (mediumKey in finalConfig) finalConfig[mediumKey] = config[e];
+      if (largeKey in finalConfig) finalConfig[largeKey] = config[e];
+    }
+  });
+
+  return finalConfig;
 };
 
 export const getMarkdownReactUiTheme = (

--- a/src/Markdown/__stories__/Markdown.stories.tsx
+++ b/src/Markdown/__stories__/Markdown.stories.tsx
@@ -1,4 +1,4 @@
-import { Modal, THEME_2022 } from '@skbkontur/react-ui';
+import { Modal, SizeProp, THEME_2022 } from '@skbkontur/react-ui';
 import { text, ValidationContainer } from '@skbkontur/react-ui-validations';
 import { Meta, Story } from '@storybook/react';
 import React, { useState } from 'react';
@@ -23,7 +23,23 @@ export default {
 
 export const WithoutActions = () => <Markdown hideMarkdownActions value={allVariantsMarkdownMock} />;
 
-export const WithActions = () => <Markdown fileApiUrl="/api/file" value={allVariantsMarkdownMock} />;
+export const WithSizeControl: Story<{ size: SizeProp }> = args => (
+  <Markdown size={args.size} value={allVariantsMarkdownMock} />
+);
+
+WithSizeControl.args = {
+  size: 'medium',
+};
+
+const sizeOptions: SizeProp[] = ['small', 'medium', 'large'];
+WithSizeControl.argTypes = {
+  size: {
+    control: {
+      type: 'select',
+      options: sizeOptions,
+    },
+  },
+};
 
 export const WithPanel = () => <Markdown borderless value={allVariantsMarkdownMock} panelHorizontalPadding={28} />;
 export const WithoutHeadersSelect = () => (


### PR DESCRIPTION
## Проблема

В https://github.com/skbkontur/retail-ui/pull/3243 добавили поддержку размеров Textarea, эта функциональность проросла в маркдаун-редактор. Многие поля из конфига темы были помечены как deprecated, для их появилась замена с суффиксами Large, Medium и Small. Если использовать параметр без суффикса, он изменит поведение только small версии.  

Таким образом не было полноценной поддержки размеров medium и large, при использовании были баги

## Решение

- Добавлена функция extendThemeConfigWithSized, которая преобразовывает базовые поля с добавлением суффиксов Large, Medium и Small.

- Добавлена стори WithSizeControl с аргументом size для управления размером редактора. 

